### PR TITLE
Allow using custom Promise-like objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ sequential(array.map((item) => {
   // ...
 })
 ```
+
+You can also use promise-sequential with non-native implementations of Promise by passing your custom Promise-like object as the second argument.

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-module.exports = function (promises) {
+module.exports = function (promises, PromiseClass = Promise) {
 
   if (!Array.isArray(promises)) {
     throw new Error('First argument need to be an array of Promises');
   }
 
-  return new Promise((resolve, reject) => {
+  return new PromiseClass((resolve, reject) => {
 
     let count = 0;
     let results = [];
@@ -20,10 +20,10 @@ module.exports = function (promises) {
         });
     }
 
-    promises = promises.concat(() => Promise.resolve());
+    promises = promises.concat(() => PromiseClass.resolve());
 
     promises
-    .reduce(iterateeFunc, Promise.resolve(false))
+    .reduce(iterateeFunc, PromiseClass.resolve(false))
     .then(function (res) {
       resolve(results);
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promise-sequential",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Simple like Promise.all(), but sequentially!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There is no need in sticking to the native implementation of Promise.

I want to use this package with https://www.npmjs.com/package/synchronous-promise which provides the same API, but async Promise is hardcoded here.