### PR TITLE
Fixes "Even if there is an error in the middle, it runs to the end"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# yarn
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -5,42 +5,19 @@ module.exports = function (promises) {
     throw new Error('First argument need to be an array of Promises');
   }
 
-  return new Promise((resolve, reject) => {
+  let count = 0;
+  let results = [];
 
-    let count = 0;
-    let results = [];
+  const iterateeFunc = (previousPromise, currentPromise) => {
+    return previousPromise
+      .then(function (result) {
+        if (count++ !== 0) results = results.concat(result);
+        return currentPromise(result, results, count);
+      })
+  }
 
-    const iterateeFunc = (previousPromise, currentPromise) => {
-      return previousPromise
-        .then(function (result) {
-          if (count++ !== 0) results = results.concat(result);
-          return currentPromise(result, results, count);
-        })
-    }
-
-    promises = promises.concat(() => Promise.resolve());
-
-    promises
-    .reduce(iterateeFunc, Promise.resolve(false))
-    .then(function (res) {
-      resolve(results);
-    })
-    /*
-      The catch below makes sequential halt the execution of promises as soon as the first promise
-      is rejected or an error is thrown.
-
-      Previously, the code used to handle errors the promise sequence within the reduce function,
-      without re-throwing them. This hid the error from the 'reduce' function, which would continue
-      to execute promises as if nothing happened. E.g.
-
-       p1.catch().p2.catch().p3.catch()
-
-      Instead, now as soon as an error is thrown, the sequential bails out. E.g.
-      p1.p2.p3.catch
-    */
-    .catch((err) => {
-      return reject(err);
-    });
-
-  });
+  return promises
+  // reduce() concatenates the promises. E.g. p1.then(p2.then(p3.then()))
+  .reduce(iterateeFunc, Promise.resolve(false))
+  .then(() => results)
 };

--- a/index.js
+++ b/index.js
@@ -25,6 +25,31 @@ module.exports = function (promises) {
     .then(function (res) {
       resolve(results);
     })
+    /*
+      The catch below makes sequential halt the execution of promises as soon as the first promise
+      is rejected or an error is thrown.
+
+      Previously, the code used to handle errors the promise sequence within the reduce function,
+      without re-throwing them. This hid the error from the 'reduce' function, which would continue
+      to execute promises as if nothing happened.
+
+      // underneath the hood the code looked like this
+      [ () => p1.catch()
+        () => p2.catch()
+        () => p3.catch()
+      ].reduce(...)
+        .then()
+
+      Instead, now as soon as an error is thrown, the reduce function is halted and an outer catch
+      block handles the error. E.g.
+
+      [ () => p1
+        () => p2
+        () => p3
+      ].reduce(...)
+          .then()
+          .catch()  <-- after first reject, this catch will execute and 'reduce' halt
+    */
     .catch((err) => {
       return reject(err);
     });

--- a/index.js
+++ b/index.js
@@ -33,13 +33,10 @@ module.exports = function (promises) {
       without re-throwing them. This hid the error from the 'reduce' function, which would continue
       to execute promises as if nothing happened. E.g.
 
-      [ () => p1.catch(), () => p2.catch(), () => p3.catch() ].reduce(...)
-        .then()
+       p1.catch().p2.catch().p3.catch()
 
       Instead, now as soon as an error is thrown, the sequential bails out. E.g.
-      [ () => p1, () => p2, () => p3 ].reduce(...)
-        .then()
-        .catch()  <-- after first reject, this catch will execute and 'reduce' halt
+      p1.p2.p3.catch
     */
     .catch((err) => {
       return reject(err);

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (promises) {
   const iterateeFunc = (previousPromise, currentPromise) => {
     return previousPromise
       .then(function (result) {
-        if (count++ !== 0) results = results.concat(result);
+        if (count++ !== 0) results.push(result);
         return currentPromise(result, results, count);
       })
   }

--- a/index.js
+++ b/index.js
@@ -31,24 +31,15 @@ module.exports = function (promises) {
 
       Previously, the code used to handle errors the promise sequence within the reduce function,
       without re-throwing them. This hid the error from the 'reduce' function, which would continue
-      to execute promises as if nothing happened.
+      to execute promises as if nothing happened. E.g.
 
-      // underneath the hood the code looked like this
-      [ () => p1.catch()
-        () => p2.catch()
-        () => p3.catch()
-      ].reduce(...)
+      [ () => p1.catch(), () => p2.catch(), () => p3.catch() ].reduce(...)
         .then()
 
-      Instead, now as soon as an error is thrown, the reduce function is halted and an outer catch
-      block handles the error. E.g.
-
-      [ () => p1
-        () => p2
-        () => p3
-      ].reduce(...)
-          .then()
-          .catch()  <-- after first reject, this catch will execute and 'reduce' halt
+      Instead, now as soon as an error is thrown, the sequential bails out. E.g.
+      [ () => p1, () => p2, () => p3 ].reduce(...)
+        .then()
+        .catch()  <-- after first reject, this catch will execute and 'reduce' halt
     */
     .catch((err) => {
       return reject(err);

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ module.exports = function (promises) {
   }
 
   return promises
+  // this call allows the last promises's resolved result to be obtained cleanly
+  .concat(() => Promise.resolve())
   // reduce() concatenates the promises. E.g. p1.then(p2).then(p3)
   .reduce(iterateeFunc, Promise.resolve(false))
   .then(() => results)

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function (promises) {
   }
 
   return promises
-  // reduce() concatenates the promises. E.g. p1.then(p2.then(p3.then()))
+  // reduce() concatenates the promises. E.g. p1.then(p2).then(p3)
   .reduce(iterateeFunc, Promise.resolve(false))
   .then(() => results)
 };

--- a/index.js
+++ b/index.js
@@ -16,9 +16,6 @@ module.exports = function (promises) {
           if (count++ !== 0) results = results.concat(result);
           return currentPromise(result, results, count);
         })
-        .catch((err) => {
-          return reject(err);
-        });
     }
 
     promises = promises.concat(() => Promise.resolve());
@@ -28,6 +25,9 @@ module.exports = function (promises) {
     .then(function (res) {
       resolve(results);
     })
+    .catch((err) => {
+      return reject(err);
+    });
 
   });
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple like Promise.all(), but sequentially!",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test --timeout 3000"
+    "test": "./node_modules/.bin/mocha test --timeout 15000"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple like Promise.all(), but sequentially!",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test --timeout 15000"
+    "test": "./node_modules/.bin/mocha test --timeout 3000"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -73,8 +73,8 @@ describe('sequentially promises', () => {
 
     Promise.resolve(
       promiseq(promises)
-      /* catching errors will force the .then of the wrapper promise to be called after the last
-         promise is executed */
+      /* catching errors will force the .then of the wrapper promise to be
+         called after the last promise is executed */
       .catch(() => {})
 
     )

--- a/test/index.js
+++ b/test/index.js
@@ -59,7 +59,6 @@ describe('sequentially promises', () => {
       In order to test the assertions each promise will update the value of a key in the
       'resolvedPromises' object. The expectation is that the 'resolvedPromises' values should
       only be updated up until the last successful promise. E.g.
-
       [ () => p1,              // updates 'resolvedPromises.p1'
         () => rejectedPromise, // should not update 'resolvedPromises.p2'
         () => p3 ]             // should not update 'resolvedPromises.p3'
@@ -84,8 +83,7 @@ describe('sequentially promises', () => {
 
     Promise.resolve(
       promiseq(promises)
-      /* The catch below prevents the '.catch' of the outer promise, thus the next '.then' will
-         only execute after 'promiseq' has finished */
+      // makes outer promise resolve only once promiseq is finished
       .catch(() => {})
 
     )

--- a/test/index.js
+++ b/test/index.js
@@ -51,4 +51,32 @@ describe('sequentially promises', () => {
       })
   });
 
+  it('should not keep running after one of the promises throws error', (done) => {
+
+    const resolvedPromises = { p1: false, p2: false, p3: false };
+    const expectedResolvedPromises = { p1: true, p2: false, p3: false };
+
+    function updateResolvedPromises(key) {
+      return new Promise((resolve) => {
+        resolvedPromises[key] = true;
+        resolve();
+      });
+    }
+
+    const promises = [
+      () => updateResolvedPromises('p1'),
+
+      () => Promise.reject(),
+
+      () => updateResolvedPromises('p3'),
+    ];
+
+    Promise.resolve(promiseq(promises))
+    .catch(() => {
+      expect(resolvedPromises).to.deep.equal(expectedResolvedPromises);
+      done();
+    })
+
+  });
+
 })

--- a/test/index.js
+++ b/test/index.js
@@ -52,7 +52,18 @@ describe('sequentially promises', () => {
   });
 
   it('should not keep running after one of the promises is rejected', (done) => {
+    /*
+      This test checks whether promise-sequential keeps executing promises after one of them
+      was rejected.
 
+      In order to test the assertions each promise will update the value of a key in the
+      'resolvedPromises' object. The expectation is that the 'resolvedPromises' values should
+      only be updated up until the last successful promise. E.g.
+
+      [ () => p1,              // updates 'resolvedPromises.p1'
+        () => rejectedPromise, // should not update 'resolvedPromises.p2'
+        () => p3 ]             // should not update 'resolvedPromises.p3'
+    */
     const resolvedPromises = { p1: false, p2: false, p3: false };
     const expectedResolvedPromises = { p1: true, p2: false, p3: false };
 
@@ -73,36 +84,9 @@ describe('sequentially promises', () => {
 
     Promise.resolve(
       promiseq(promises)
-      .catch(() => {
-        /*
-          This catch block exists in order to force the '.then' of the wrapper promise
-          (Promise.resolve(...) above ) to execute. If the behavior this test is protecting against
-          occurs, 'promiseq' will continue calling promises in sequence even after this
-          catch block was executed. After 'promiseq' is resolved, the expectations can be tested
-          inside the next '.then' block. Without this catch block, the catch block of
-          Promise.resolve(...) should be called immeditely, but it would not be possible to detect
-          if anything was executed afterwards.
-
-          Underneath the hood, promise-sequential uses a reduce function which originally called
-          every promise in the sequence in the following way:
-
-          [ () => updateResolvedPromises('p1').catch().then()
-            () => Promise.reject().catch(() => reject()).then()   <--- Rejects 'promiseq' but reduce function not interrupted
-            () => updateResolvedPromises('p3').catch().then()     <--- will execute anyway
-          ].reduce(...)
-            .then()
-
-          Instead, as soon as the first promise is rejected, the error thrown should bail out
-          by executing the 'promiseq' catch block outside of the reduce. E.g.
-
-          [ () => updateResolvedPromises('p1')
-            () => Promise.reject())
-            () => .then(updateResolvedPromises('p3'))
-          ].reduce(...)
-              .then()
-              .catch(() => reject())  <-- after first reject, reduce will stop execution
-        */
-      })
+      /* The catch below prevents the '.catch' of the outer promise, thus the next '.then' will
+         only execute after 'promiseq' has finished */
+      .catch(() => {})
 
     )
     .then(() => {

--- a/test/index.js
+++ b/test/index.js
@@ -23,16 +23,14 @@ describe('sequentially promises', () => {
       }
 
     });
-    const array = [1,2,3,4]
     promiseq(promises)
       .then(res => {
-        expect(res).to.be.instanceof(Array);
+        expect(res).to.be.instanceof(Array)
         done();
-      });
-
+      })
   });
 
-  it('should return 1 as param of catch function', (done) => {
+  it('should be able to catch value passed on reject of a promise', (done) => {
 
     let promises = [1,2].map((item) => {
       return function (previousResponse) {
@@ -49,6 +47,16 @@ describe('sequentially promises', () => {
         expect(err).to.equal(1);
         done();
       })
+  });
+
+  it('should handle case where input array is empty', (done) => {
+
+    const expectedResult = [];
+    promiseq([])
+      .then((res) => {
+        expect(res).to.deep.equal(expectedResult);
+        done();
+      });
   });
 
   it('should not keep running after one of the promises is rejected', (done) => {
@@ -81,16 +89,12 @@ describe('sequentially promises', () => {
       () => updateResolvedPromises('p3'),
     ];
 
-    Promise.resolve(
-      promiseq(promises)
-      // makes outer promise resolve only once promiseq is finished
+    promiseq(promises)
       .catch(() => {})
-
-    )
-    .then(() => {
-      expect(resolvedPromises).to.deep.equal(expectedResolvedPromises);
-      done();
-    })
+      .then(() => {
+        expect(resolvedPromises).to.deep.equal(expectedResolvedPromises);
+        done();
+      })
   });
 
 })

--- a/test/index.js
+++ b/test/index.js
@@ -10,9 +10,11 @@ describe('sequentially promises', () => {
     expect(func).to.throw('First argument need to be an array of Promises');
   });
 
-  it('should return an Array as response', (done) => {
+  it('should return an Array containing all promises resolved results as response', (done) => {
 
-    let promises = [1,2].map((item) => {
+    const vals = [1, 2, 3]
+
+    let promises = vals.map((item) => {
 
       return function (previousResponse, results, count) {
         return new Promise(resolve => {
@@ -25,7 +27,8 @@ describe('sequentially promises', () => {
     });
     promiseq(promises)
       .then(res => {
-        expect(res).to.be.instanceof(Array)
+        expect(res).to.be.instanceof(Array);
+        expect(res).to.eql(vals);
         done();
       })
   });

--- a/test/index.js
+++ b/test/index.js
@@ -73,9 +73,32 @@ describe('sequentially promises', () => {
 
     Promise.resolve(
       promiseq(promises)
-      /* catching errors will force the .then of the wrapper promise to be
-         called after the last promise is executed */
-      .catch(() => {})
+      .catch(() => {
+        /*
+          This catch block exists in order to force the '.then' of the wrapper promise
+          (Promise.resolve(...) ) to execute. If the behavior this test is protecting against
+          occurs, promiseq will continue calling promises in sequence even after this
+          catch block was executed. After 'promiseq' is resolved, the expectations can be tested
+          inside the next '.then' block. Without this catch block, the catch block of
+          Promise.resolve(...) should be called immeditely, but it would not be possible to detect
+          if anything was executed afterwards.
+
+          Underneath the hood, promise-sequential uses a reduce function which originally called
+          every promise in the sequence in the following way:
+
+          updateResolvedPromises('p1').catch()
+          Promise.reject().catch(() => reject())   <--- Rejects 'promiseq' but reduce function not interrupted
+          updateResolvedPromises('p3').catch()     <--- will execute anyway
+
+          Instead, as soon as the first promise is rejected, the error thrown should interrup the
+          reduce function and bail out. E.g.
+
+          updateResolvedPromises('p1')
+          .then(Promise.reject())
+          .then(updateResolvedPromises('p3'))
+          .catch(() => reject())
+        */
+      })
 
     )
     .then(() => {

--- a/test/index.js
+++ b/test/index.js
@@ -51,7 +51,7 @@ describe('sequentially promises', () => {
       })
   });
 
-  it('should not keep running after one of the promises throws error', (done) => {
+  it('should not keep running after one of the promises is rejected', (done) => {
 
     const resolvedPromises = { p1: false, p2: false, p3: false };
     const expectedResolvedPromises = { p1: true, p2: false, p3: false };
@@ -71,12 +71,17 @@ describe('sequentially promises', () => {
       () => updateResolvedPromises('p3'),
     ];
 
-    Promise.resolve(promiseq(promises))
-    .catch(() => {
+    Promise.resolve(
+      promiseq(promises)
+      /* catching errors will force the .then of the wrapper promise to be called after the last
+         promise is executed */
+      .catch(() => {})
+
+    )
+    .then(() => {
       expect(resolvedPromises).to.deep.equal(expectedResolvedPromises);
       done();
     })
-
   });
 
 })


### PR DESCRIPTION
Fixes #9 

In this PR:
- sequential now stops executing promises after the first reject
- some code cleanup